### PR TITLE
add web3 poller

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -36,5 +36,6 @@ module.exports = {
     reward_token_erc20_abi: require('./contracts/zippieRewardTokenERC20Abi'),
     reward_token_erc20_factory_abi: require('./contracts/zippieRewardTokenERC20FactoryAbi'),
     internal_token_erc20_abi: require('./contracts/zippieInternalTokenERC20Abi'),
+    poll: require('./poll'),
     utils: require('./utility')
   }

--- a/src/poll.js
+++ b/src/poll.js
@@ -1,0 +1,37 @@
+let __web3 = null
+let __interval = 10000
+let __isRunning = false
+
+function setup(web3, interval) {
+    __web3 = web3
+    __interval = interval
+}
+
+function start() {
+    __isRunning = true
+    sync()
+}
+
+function stop() {
+    __isRunning = false
+}
+
+async function sync() {
+    while(__isRunning) { 
+        try {
+            const block = await __web3.eth.getBlock('latest')
+        } catch(error) {
+
+        }
+
+        await timeout(__interval)
+    }    
+}
+
+function timeout (duration) {
+    return new Promise(resolve => {
+      setTimeout(resolve, duration)
+    })
+  }
+
+  module.exports = {setup, start, stop}


### PR DESCRIPTION
add a web3 poller for use in backend services, since web3 likes to silently fail its websockets connections leading to a number of issues